### PR TITLE
Fix judgment race condition, BPM calculation for speed-changing levels, auto-play false deaths, and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build output
+bin/
+obj/
+
+# IDE
+.vs/
+.vscode/
+*.suo
+*.user
+*.csproj.user
+
+# Tools
+.codegraph/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/AccuracySystem.cs
+++ b/AccuracySystem.cs
@@ -166,25 +166,18 @@ namespace XPerfect
     {
         static void Postfix(ref HitMargin __result, float hitangle, float refangle, bool isCW, float bpmTimesSpeed, float conductorPitch, double marginScale = 1f)
         {
-            try
-            {
-                if (!Main.Enabled) return;
-                if (scrController.instance == null || scrConductor.instance == null) return;
-                if ((States)scrController.instance.stateMachine.GetState() != States.PlayerControl) return;
+            if (!Main.Enabled) return;
+            if (scrController.instance == null || scrConductor.instance == null) return;
+            if ((States)scrController.instance.stateMachine.GetState() != States.PlayerControl) return;
 
-                double bpmTimesSpeed2 = (double)bpmTimesSpeed;
-                double conductorPitch2 = (double)conductorPitch;
+            double bpmTimesSpeed2 = (double)bpmTimesSpeed;
+            double conductorPitch2 = (double)conductorPitch;
 
-                DetailedJudge detailedJudge = JudgeCalculator.GetDetailedJudge(
-                    __result, hitangle, refangle, isCW, bpmTimesSpeed2, conductorPitch2);
+            DetailedJudge detailedJudge = JudgeCalculator.GetDetailedJudge(
+                __result, hitangle, refangle, isCW, bpmTimesSpeed2, conductorPitch2);
 
-                if (detailedJudge != DetailedJudge.None)
-                    AccuracyState.RecordJudge(detailedJudge);
-            }
-            catch (Exception ex)
-            {
-                UnityModManager.Logger.Log($"[XPerfect] HitMargin error: {ex}");
-            }
+            if (detailedJudge != DetailedJudge.None)
+                AccuracyState.RecordJudge(detailedJudge);
         }
     }
 
@@ -196,33 +189,26 @@ namespace XPerfect
 
         static void Postfix(ref bool __result, HitMargin margin)
         {
-            try
+            if (!Main.Enabled || !Main.Settings.XPerfectOnly) return;
+            if (scrController.instance == null || !scrController.instance.gameworld) return;
+
+            bool shouldBlock = false;
+
+            if (margin != HitMargin.Perfect)
             {
-                if (!Main.Enabled || !Main.Settings.XPerfectOnly) return;
-                if (scrController.instance == null || !scrController.instance.gameworld) return;
-
-                bool shouldBlock = false;
-
-                if (margin != HitMargin.Perfect)
-                {
-                    shouldBlock = true;
-                }
-                else
-                {
-                    DetailedJudge judge = AccuracyState.LastJudge;
-                    if (judge == DetailedJudge.PlusPerfect || judge == DetailedJudge.MinusPerfect)
-                        shouldBlock = true;
-                }
-
-                if (shouldBlock)
-                {
-                    __result = false;
-                    ShouldFailPlayer = true;
-                }
+                shouldBlock = true;
             }
-            catch (Exception ex)
+            else
             {
-                UnityModManager.Logger.Log($"[XPerfect] IsValidHit error: {ex}");
+                DetailedJudge judge = AccuracyState.LastJudge;
+                if (judge == DetailedJudge.PlusPerfect || judge == DetailedJudge.MinusPerfect)
+                    shouldBlock = true;
+            }
+
+            if (shouldBlock)
+            {
+                __result = false;
+                ShouldFailPlayer = true;
             }
         }
     }
@@ -258,23 +244,18 @@ namespace XPerfect
     {
         static void Postfix(HitMargin hit)
         {
-            try
-            {
-                if (!Main.Enabled) return;
-                if (hit != HitMargin.Perfect) return;
-                if (scrController.instance == null || scrConductor.instance == null) return;
-                if ((States)scrController.instance.stateMachine.GetState() != States.PlayerControl) return;
+            if (!Main.Enabled) return;
+            if (hit != HitMargin.Perfect) return;
+            if (scrController.instance == null || scrConductor.instance == null) return;
+            if ((States)scrController.instance.stateMachine.GetState() != States.PlayerControl) return;
 
-                DetailedJudge detailedJudge = AccuracyState.LastJudge;
-                if (detailedJudge == DetailedJudge.None) return;
+            DetailedJudge detailedJudge = AccuracyState.LastJudge;
+            if (detailedJudge == DetailedJudge.None) return;
 
-                AccuracyState.IncrementCount(detailedJudge);
-                AccuracyState.ConsumeJudge();
-            }
-            catch (Exception ex)
-            {
-                UnityModManager.Logger.Log($"[XPerfect] AddHit error: {ex}");
-            }
+            AccuracyState.IncrementCount(detailedJudge);
+            AccuracyState.ConsumeJudge();
+
+            CounterDisplay.Refresh();
         }
     }
 
@@ -409,6 +390,7 @@ namespace XPerfect
         {
             AccuracyState.Reset();
             IsValidHitPatch.ShouldFailPlayer = false;
+            CounterDisplay.Refresh();
         }
     }
 

--- a/AccuracySystem.cs
+++ b/AccuracySystem.cs
@@ -22,7 +22,6 @@ namespace XPerfect
 
         public static DetailedJudge LastJudge { get; private set; } = DetailedJudge.None;
         public static DetailedJudge LastJudgeForText { get; private set; } = DetailedJudge.None;
-        public static bool LastJudgeConsumedByMeter { get; private set; } = false;
 
         public static void RecordJudge(DetailedJudge judge)
         {
@@ -37,11 +36,6 @@ namespace XPerfect
         public static void ConsumeJudgeForText()
         {
             LastJudgeForText = DetailedJudge.None;
-        }
-
-        public static void SetMeterConsumed(bool value)
-        {
-            LastJudgeConsumedByMeter = value;
         }
 
         public static void IncrementCount(DetailedJudge judge)
@@ -61,7 +55,6 @@ namespace XPerfect
             MinusPerfectCount = 0;
             LastJudge = DetailedJudge.None;
             LastJudgeForText = DetailedJudge.None;
-            LastJudgeConsumedByMeter = false;
         }
     }
 
@@ -120,6 +113,14 @@ namespace XPerfect
                 marginScale
             );
 
+            return GetMeterXPerfectBoundaryDeg(bpmTimesSpeed, conductorPitch, countedBoundaryDeg);
+        }
+
+        public static double GetMeterXPerfectBoundaryDeg(
+            double bpmTimesSpeed,
+            double conductorPitch,
+            double countedBoundaryDeg)
+        {
             double actualXPerfectBoundaryDeg = GetActualXPerfectBoundaryDeg(bpmTimesSpeed, conductorPitch);
             double meterScale = GetMeterScale(countedBoundaryDeg);
 
@@ -234,9 +235,10 @@ namespace XPerfect
         {
             try
             {
-                if (!Main.Enabled || !Main.Settings.XPerfectOnly) return;
                 if (!IsValidHitPatch.ShouldFailPlayer) return;
                 IsValidHitPatch.ShouldFailPlayer = false;
+
+                if (!Main.Enabled || !Main.Settings.XPerfectOnly) return;
 
                 var ctrl = scrController.instance;
                 if (ctrl == null) return;
@@ -267,9 +269,7 @@ namespace XPerfect
                 if (detailedJudge == DetailedJudge.None) return;
 
                 AccuracyState.IncrementCount(detailedJudge);
-
-                if (!AccuracyState.LastJudgeConsumedByMeter)
-                    AccuracyState.ConsumeJudge();
+                AccuracyState.ConsumeJudge();
             }
             catch (Exception ex)
             {

--- a/AccuracySystem.cs
+++ b/AccuracySystem.cs
@@ -69,22 +69,6 @@ namespace XPerfect
             return isCW ? delta : -delta;
         }
 
-        public static double GetBpmTimesSpeed()
-        {
-            if (scrConductor.instance == null || scrController.instance == null)
-                return 0.0;
-
-            return scrConductor.instance.bpm * GCS.currentSpeedTrial * ADOBase.controller.playerOne.planetarySystem.speed;
-        }
-
-        public static double GetConductorPitch()
-        {
-            if (scrConductor.instance == null || scrConductor.instance.song == null)
-                return 1.0;
-
-            return scrConductor.instance.song.pitch;
-        }
-
         public static double GetActualXPerfectBoundaryDeg(double bpmTimesSpeed, double conductorPitch)
         {
             double xPerfectMinTimeDeg =
@@ -138,11 +122,11 @@ namespace XPerfect
             double bpmTimesSpeed,
             double conductorPitch)
         {
-            if (result != HitMargin.Perfect)
-                return DetailedJudge.None;
-
             if (RDC.auto)
                 return DetailedJudge.XPerfect;
+
+            if (result != HitMargin.Perfect)
+                return DetailedJudge.None;
 
             float signedDeltaDeg = AccuracyMath.GetSignedDeltaDeg(hitAngle, refAngle, isCW);
             float absDeltaDeg = Mathf.Abs(signedDeltaDeg);
@@ -191,6 +175,8 @@ namespace XPerfect
         {
             if (!Main.Enabled || !Main.Settings.XPerfectOnly) return;
             if (scrController.instance == null || !scrController.instance.gameworld) return;
+
+            if (RDC.auto) return;
 
             bool shouldBlock = false;
 

--- a/Counterdisplay.cs
+++ b/Counterdisplay.cs
@@ -13,8 +13,14 @@ namespace XPerfect
         private static readonly Color32 PlusMinusColor = new Color32(96, 255, 78, 255);
         private static readonly Color32 XColor = new Color32(77, 204, 255, 255);
 
+        private static readonly string PlusMinusHex = ColorUtility.ToHtmlStringRGB(PlusMinusColor);
+        private static readonly string XColorHex = ColorUtility.ToHtmlStringRGB(XColor);
+
         private static string _cachedSpace = "";
         private static int _lastSpacing = -1;
+
+        private static Vector2 _lastAppliedPos = Vector2.zero;
+        private static int _lastAppliedFontSize = -1;
 
         private static GameObject _canvasObj;
         private static TMP_Text _text;
@@ -35,8 +41,8 @@ namespace XPerfect
             var scaler = _canvasObj.AddComponent<CanvasScaler>();
             scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
             scaler.referenceResolution = new Vector2(
-                Screen.currentResolution.width,
-                Screen.currentResolution.height
+                Screen.width,
+                Screen.height
             );
 
             _text = CreateLabel(_canvasObj);
@@ -113,7 +119,7 @@ namespace XPerfect
                 UnityModManager.Logger.Log($"[XPerfect] RDString.fontData error: {ex}");
             }
 
-            foreach (var t in UnityEngine.Object.FindObjectsOfType<TMP_Text>())
+            foreach (var t in UnityEngine.Object.FindObjectsByType<TMP_Text>(FindObjectsSortMode.None))
             {
                 if (t == null || t.font == null) continue;
                 if (ReferenceEquals(t, _text)) continue;
@@ -127,11 +133,18 @@ namespace XPerfect
         {
             if (_text == null) return;
 
-            _text.rectTransform.anchoredPosition = new Vector2(
-                Main.Settings.CounterX,
-                Main.Settings.CounterY
-            );
-            _text.fontSize = Main.Settings.CounterFontSize;
+            Vector2 pos = new Vector2(Main.Settings.CounterX, Main.Settings.CounterY);
+            if (pos != _lastAppliedPos)
+            {
+                _text.rectTransform.anchoredPosition = pos;
+                _lastAppliedPos = pos;
+            }
+
+            if (Main.Settings.CounterFontSize != _lastAppliedFontSize)
+            {
+                _text.fontSize = Main.Settings.CounterFontSize;
+                _lastAppliedFontSize = Main.Settings.CounterFontSize;
+            }
         }
 
         public static void Refresh()
@@ -150,11 +163,11 @@ namespace XPerfect
             string space = GetSpace();
 
             _text.text =
-                $"{ColorText(AccuracyState.PlusPerfectCount.ToString(), PlusMinusColor)}" +
+                $"{ColorText(AccuracyState.PlusPerfectCount.ToString(), PlusMinusHex)}" +
                 $"{space}" +
-                $"{ColorText(AccuracyState.XPerfectCount.ToString(), XColor)}" +
+                $"{ColorText(AccuracyState.XPerfectCount.ToString(), XColorHex)}" +
                 $"{space}" +
-                $"{ColorText(AccuracyState.MinusPerfectCount.ToString(), PlusMinusColor)}";
+                $"{ColorText(AccuracyState.MinusPerfectCount.ToString(), PlusMinusHex)}";
 
             ApplySettings();
         }
@@ -170,9 +183,9 @@ namespace XPerfect
             return _cachedSpace;
         }
 
-        private static string ColorText(string text, Color32 color)
+        private static string ColorText(string text, string colorHex)
         {
-            return $"<color=#{ColorUtility.ToHtmlStringRGB(color)}>{text}</color>";
+            return $"<color=#{colorHex}>{text}</color>";
         }
     }
 

--- a/Counterdisplay.cs
+++ b/Counterdisplay.cs
@@ -5,6 +5,7 @@ using UnityEngine.UI;
 using UnityModManagerNet;
 using System;
 using System.Collections;
+using System.Text;
 
 namespace XPerfect
 {
@@ -25,6 +26,8 @@ namespace XPerfect
         private static GameObject _canvasObj;
         private static TMP_Text _text;
         private static TMP_FontAsset _cachedFont;
+
+        private static readonly StringBuilder _counterBuilder = new StringBuilder(128);
 
 
         public static void Create()
@@ -162,14 +165,56 @@ namespace XPerfect
 
             string space = GetSpace();
 
-            _text.text =
-                $"{ColorText(AccuracyState.PlusPerfectCount.ToString(), PlusMinusHex)}" +
-                $"{space}" +
-                $"{ColorText(AccuracyState.XPerfectCount.ToString(), XColorHex)}" +
-                $"{space}" +
-                $"{ColorText(AccuracyState.MinusPerfectCount.ToString(), PlusMinusHex)}";
+            var sb = _counterBuilder;
+            sb.Length = 0;
+
+            sb.Append("<color=#");
+            sb.Append(PlusMinusHex);
+            sb.Append(">+");
+            AppendInt(sb, AccuracyState.PlusPerfectCount);
+            sb.Append("</color>");
+            sb.Append(space);
+            sb.Append("<color=#");
+            sb.Append(XColorHex);
+            sb.Append(">");
+            AppendInt(sb, AccuracyState.XPerfectCount);
+            sb.Append("</color>");
+            sb.Append(space);
+            sb.Append("<color=#");
+            sb.Append(PlusMinusHex);
+            sb.Append(">-");
+            AppendInt(sb, AccuracyState.MinusPerfectCount);
+            sb.Append("</color>");
+
+            _text.text = sb.ToString();
 
             ApplySettings();
+        }
+
+        private static void AppendInt(StringBuilder sb, int value)
+        {
+            if (value >= 1000)
+            {
+                sb.Append((char)('0' + (value / 1000) % 10));
+                sb.Append((char)('0' + (value / 100) % 10));
+                sb.Append((char)('0' + (value / 10) % 10));
+                sb.Append((char)('0' + value % 10));
+            }
+            else if (value >= 100)
+            {
+                sb.Append((char)('0' + (value / 100) % 10));
+                sb.Append((char)('0' + (value / 10) % 10));
+                sb.Append((char)('0' + value % 10));
+            }
+            else if (value >= 10)
+            {
+                sb.Append((char)('0' + (value / 10) % 10));
+                sb.Append((char)('0' + value % 10));
+            }
+            else
+            {
+                sb.Append((char)('0' + value));
+            }
         }
 
         private static string GetSpace()
@@ -181,11 +226,6 @@ namespace XPerfect
                 _lastSpacing = s;
             }
             return _cachedSpace;
-        }
-
-        private static string ColorText(string text, string colorHex)
-        {
-            return $"<color=#{colorHex}>{text}</color>";
         }
     }
 
@@ -231,16 +271,6 @@ namespace XPerfect
         }
     }
 
-    [HarmonyPatch(typeof(scrMarginTracker), "AddHit")]
-    public static class CounterRefreshOnHitPatch
-    {
-        static void Postfix()
-        {
-            try { CounterDisplay.Refresh(); }
-            catch (Exception ex) { UnityModManager.Logger.Log($"[XPerfect] CounterRefresh error: {ex}"); }
-        }
-    }
-
     [HarmonyPatch(typeof(scnEditor), "SwitchToEditMode")]
     public static class EditorSwitchToEditModePatch
     {
@@ -248,16 +278,6 @@ namespace XPerfect
         {
             try { CounterDisplay.Refresh(); }
             catch (Exception ex) { UnityModManager.Logger.Log($"[XPerfect] SwitchToEditMode error: {ex}"); }
-        }
-    }
-
-    [HarmonyPatch(typeof(scrController), "Start_Rewind")]
-    public static class CounterResetOnStartPatch
-    {
-        static void Postfix()
-        {
-            try { CounterDisplay.Refresh(); }
-            catch (Exception ex) { UnityModManager.Logger.Log($"[XPerfect] CounterReset error: {ex}"); }
         }
     }
 }

--- a/MeterVisualPatch.cs
+++ b/MeterVisualPatch.cs
@@ -11,25 +11,23 @@ namespace XPerfect
     [HarmonyPatch]
     public static class MeterVisualPatch
     {
-        private static readonly FieldInfo CachedTickImagesField =
-            AccessTools.Field(typeof(scrHitErrorMeter), "cachedTickImages");
+        private static readonly AccessTools.FieldRef<scrHitErrorMeter, Image[]> GetCachedTickImages =
+            AccessTools.FieldRefAccess<scrHitErrorMeter, Image[]>("cachedTickImages");
 
-        private static readonly FieldInfo TickIndexField =
-            AccessTools.Field(typeof(scrHitErrorMeter), "tickIndex");
+        private static readonly AccessTools.FieldRef<scrHitErrorMeter, int> GetTickIndex =
+            AccessTools.FieldRefAccess<scrHitErrorMeter, int>("tickIndex");
 
-        private static readonly FieldInfo TickCacheSizeField =
-            AccessTools.Field(typeof(scrHitErrorMeter), "tickCacheSize");
+        private static readonly AccessTools.FieldRef<scrHitErrorMeter, int> GetTickCacheSize =
+            AccessTools.FieldRefAccess<scrHitErrorMeter, int>("tickCacheSize");
 
-        private static readonly FieldInfo MeterShapeField =
-            AccessTools.Field(typeof(scrHitErrorMeter), "meterShape");
+        private static readonly AccessTools.FieldRef<scrHitErrorMeter, ErrorMeterShape> GetMeterShape =
+            AccessTools.FieldRefAccess<scrHitErrorMeter, ErrorMeterShape>("meterShape");
 
         private static Sprite straightSprite;
         private static Sprite curvedSprite;
-        private static bool loaded = false;
 
         private static Sprite originalStraightSprite;
         private static Sprite originalCurvedSprite;
-        private static bool originalSpritesCaptured = false;
 
         [HarmonyPatch(typeof(scrHitErrorMeter), "UpdateLayout")]
         [HarmonyPostfix]
@@ -96,13 +94,13 @@ namespace XPerfect
                 if (scrConductor.instance == null || scrController.instance == null)
                     return;
 
-                Image[] cachedTickImages = CachedTickImagesField.GetValue(__instance) as Image[];
+                Image[] cachedTickImages = GetCachedTickImages(__instance);
                 if (cachedTickImages == null || cachedTickImages.Length == 0)
                     return;
 
-                int tickIndex = (int)TickIndexField.GetValue(__instance);
-                int tickCacheSize = (int)TickCacheSizeField.GetValue(__instance);
-                ErrorMeterShape meterShape = (ErrorMeterShape)MeterShapeField.GetValue(__instance);
+                int tickIndex = GetTickIndex(__instance);
+                int tickCacheSize = GetTickCacheSize(__instance);
+                ErrorMeterShape meterShape = GetMeterShape(__instance);
 
                 int justAddedTickIndex = tickIndex - 1;
                 if (justAddedTickIndex < 0)
@@ -147,14 +145,14 @@ namespace XPerfect
 
                 const float xCompress = 0.75f;
 
-                if (AccuracyState.LastJudge == DetailedJudge.XPerfect)
+                double xPerfectMeterBoundary = AccuracyMath.GetMeterXPerfectBoundaryDeg(
+                    bpmTimesSpeed, conductorPitch, countedBoundaryDeg);
+
+                if (Math.Abs(normalizedAngle) <= xPerfectMeterBoundary)
                 {
                     float finalAngle = normalizedAngle * xCompress;
                     ApplyTickAngle(tickImage, meterShape, finalAngle);
                 }
-
-                AccuracyState.SetMeterConsumed(true);
-                AccuracyState.ConsumeJudge();
             }
             catch (Exception ex)
             {
@@ -218,8 +216,6 @@ namespace XPerfect
                 if (image != null && image.sprite != curvedSprite)
                     originalCurvedSprite = image.sprite;
             }
-
-            originalSpritesCaptured = originalStraightSprite != null || originalCurvedSprite != null;
         }
 
         private static void RestoreOriginalSprites(scrHitErrorMeter meter)
@@ -277,27 +273,26 @@ namespace XPerfect
 
         private static void EnsureSpritesLoaded()
         {
-            if (loaded)
-                return;
-
             try
             {
                 string modPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                string straightPath = Path.Combine(modPath, "XStraightMeter.png");
-                string curvedPath = Path.Combine(modPath, "XCurvedMeter.png");
 
-                straightSprite = LoadSprite(straightPath);
-                curvedSprite = LoadSprite(curvedPath);
+                if (straightSprite == null)
+                {
+                    string straightPath = Path.Combine(modPath, "XStraightMeter.png");
+                    straightSprite = LoadSprite(straightPath);
+                }
+
+                if (curvedSprite == null)
+                {
+                    string curvedPath = Path.Combine(modPath, "XCurvedMeter.png");
+                    curvedSprite = LoadSprite(curvedPath);
+                }
             }
             catch (Exception ex)
             {
                 UnityModManager.Logger.Log($"[MeterVisualPatch/EnsureSpritesLoaded] {ex}");
             }
-            finally
-            {
-                loaded = straightSprite != null || curvedSprite != null;
-            }
-
         }
 
         private static Sprite LoadSprite(string filePath)
@@ -339,7 +334,7 @@ namespace XPerfect
         {
             try
             {
-                scrHitErrorMeter[] meters = UnityEngine.Object.FindObjectsOfType<scrHitErrorMeter>(true);
+                scrHitErrorMeter[] meters = UnityEngine.Object.FindObjectsByType<scrHitErrorMeter>(FindObjectsSortMode.None);
                 if (meters == null || meters.Length == 0)
                     return;
 

--- a/MeterVisualPatch.cs
+++ b/MeterVisualPatch.cs
@@ -150,36 +150,28 @@ namespace XPerfect
             [HarmonyPrefix]
             public static bool Prefix(ref Color __result, float angle, float marginScale = 1f, scrFloor hitFloor = null)
             {
-                try
-                {
-                    if (!Main.Enabled)
-                        return true;
-
-                    if (scrController.instance == null || scrConductor.instance == null)
-                        return true;
-
-                    double bpmTimesSpeed = scrConductor.instance.bpm * ((hitFloor ?? scrController.instance.playerOne?.currFloor?.prevfloor)?.speed ?? 1.0);
-                    double conductorPitch = scrConductor.instance.song.pitch;
-
-                    double xPerfectBoundary = AccuracyMath.GetMeterXPerfectBoundaryDeg(
-                        bpmTimesSpeed,
-                        conductorPitch,
-                        marginScale
-                    );
-
-                    if (Math.Abs(angle) <= xPerfectBoundary)
-                    {
-                        __result = new Color(0.3f, 0.8f, 1f, 1f);
-                        return false;
-                    }
-
+                if (!Main.Enabled)
                     return true;
-                }
-                catch (Exception ex)
-                {
-                    UnityModManager.Logger.Log($"[MeterTickColorPatch] {ex}");
+
+                if (scrController.instance == null || scrConductor.instance == null)
                     return true;
+
+                double bpmTimesSpeed = scrConductor.instance.bpm * ((hitFloor ?? scrController.instance.playerOne?.currFloor?.prevfloor)?.speed ?? 1.0);
+                double conductorPitch = scrConductor.instance.song.pitch;
+
+                double xPerfectBoundary = AccuracyMath.GetMeterXPerfectBoundaryDeg(
+                    bpmTimesSpeed,
+                    conductorPitch,
+                    marginScale
+                );
+
+                if (Math.Abs(angle) <= xPerfectBoundary)
+                {
+                    __result = new Color(0.3f, 0.8f, 1f, 1f);
+                    return false;
                 }
+
+                return true;
             }
         }
 

--- a/MeterVisualPatch.cs
+++ b/MeterVisualPatch.cs
@@ -83,80 +83,63 @@ namespace XPerfect
         [HarmonyPostfix]
         public static void AddHitPostfix(scrHitErrorMeter __instance, float angleDiff, float marginScale = 1f, scrPlanet planet = null, scrFloor hitFloor = null)
         {
-            try
+            if (!Main.Enabled)
+                return;
+
+            if (__instance == null)
+                return;
+
+            if (scrConductor.instance == null || scrController.instance == null)
+                return;
+
+            Image[] cachedTickImages = GetCachedTickImages(__instance);
+            if (cachedTickImages == null || cachedTickImages.Length == 0)
+                return;
+
+            int tickIndex = GetTickIndex(__instance);
+            int tickCacheSize = GetTickCacheSize(__instance);
+            ErrorMeterShape meterShape = GetMeterShape(__instance);
+
+            int justAddedTickIndex = tickIndex - 1;
+            if (justAddedTickIndex < 0)
+                justAddedTickIndex = tickCacheSize - 1;
+
+            if (justAddedTickIndex < 0 || justAddedTickIndex >= cachedTickImages.Length)
+                return;
+
+            Image tickImage = cachedTickImages[justAddedTickIndex];
+            if (tickImage == null)
+                return;
+
+            float normalizedAngle = GetMeterAngleFromTick(tickImage, meterShape);
+
+            double bpmTimesSpeed = AccuracyMath.GetBpmTimesSpeed();
+            double conductorPitch = AccuracyMath.GetConductorPitch();
+
+            double pureBoundaryDeg = scrMisc.GetAdjustedAngleBoundaryInDeg(
+                HitMarginGeneral.Pure, bpmTimesSpeed, conductorPitch, marginScale);
+
+            double countedBoundaryDeg = scrMisc.GetAdjustedAngleBoundaryInDeg(
+                HitMarginGeneral.Counted, bpmTimesSpeed, conductorPitch, marginScale);
+
+            if (countedBoundaryDeg <= 0.0)
+                return;
+
+            double scale = 60.0 / countedBoundaryDeg;
+            double normalizedPureBoundary = pureBoundaryDeg * scale;
+
+            if (normalizedAngle < -normalizedPureBoundary || normalizedAngle > normalizedPureBoundary)
+                return;
+
+            const float xCompress = 0.75f;
+
+            double xPerfectMeterBoundary = AccuracyMath.GetMeterXPerfectBoundaryDeg(
+                bpmTimesSpeed, conductorPitch, countedBoundaryDeg);
+
+            if (Math.Abs(normalizedAngle) <= xPerfectMeterBoundary)
             {
-                if (!Main.Enabled)
-                    return;
-
-                if (__instance == null)
-                    return;
-
-                if (scrConductor.instance == null || scrController.instance == null)
-                    return;
-
-                Image[] cachedTickImages = GetCachedTickImages(__instance);
-                if (cachedTickImages == null || cachedTickImages.Length == 0)
-                    return;
-
-                int tickIndex = GetTickIndex(__instance);
-                int tickCacheSize = GetTickCacheSize(__instance);
-                ErrorMeterShape meterShape = GetMeterShape(__instance);
-
-                int justAddedTickIndex = tickIndex - 1;
-                if (justAddedTickIndex < 0)
-                    justAddedTickIndex = tickCacheSize - 1;
-
-                if (justAddedTickIndex < 0 || justAddedTickIndex >= cachedTickImages.Length)
-                    return;
-
-                Image tickImage = cachedTickImages[justAddedTickIndex];
-                if (tickImage == null)
-                    return;
-
-                float normalizedAngle = GetMeterAngleFromTick(tickImage, meterShape);
-
-                double bpmTimesSpeed = AccuracyMath.GetBpmTimesSpeed();
-                double conductorPitch = AccuracyMath.GetConductorPitch();
-
-                double pureBoundaryDeg = scrMisc.GetAdjustedAngleBoundaryInDeg(
-                    HitMarginGeneral.Pure,
-                    bpmTimesSpeed,
-                    conductorPitch,
-                    marginScale
-                );
-
-                double countedBoundaryDeg = scrMisc.GetAdjustedAngleBoundaryInDeg(
-                    HitMarginGeneral.Counted,
-                    bpmTimesSpeed,
-                    conductorPitch,
-                    marginScale
-                );
-
-                if (countedBoundaryDeg <= 0.0)
-                    return;
-
-                double scale = 60.0 / countedBoundaryDeg;
-                double normalizedPureBoundary = pureBoundaryDeg * scale;
-
-                if (normalizedAngle < -normalizedPureBoundary || normalizedAngle > normalizedPureBoundary)
-                {
-                    return;
-                }
-
-                const float xCompress = 0.75f;
-
-                double xPerfectMeterBoundary = AccuracyMath.GetMeterXPerfectBoundaryDeg(
-                    bpmTimesSpeed, conductorPitch, countedBoundaryDeg);
-
-                if (Math.Abs(normalizedAngle) <= xPerfectMeterBoundary)
-                {
-                    float finalAngle = normalizedAngle * xCompress;
-                    ApplyTickAngle(tickImage, meterShape, finalAngle);
-                }
-            }
-            catch (Exception ex)
-            {
-                UnityModManager.Logger.Log($"[MeterVisualPatch/AddHit] {ex}");
+                float finalAngle = normalizedAngle * xCompress;
+                ApplyTickAngle(tickImage, meterShape, finalAngle);
             }
         }
 

--- a/MeterVisualPatch.cs
+++ b/MeterVisualPatch.cs
@@ -113,8 +113,9 @@ namespace XPerfect
 
             float normalizedAngle = GetMeterAngleFromTick(tickImage, meterShape);
 
-            double bpmTimesSpeed = AccuracyMath.GetBpmTimesSpeed();
-            double conductorPitch = AccuracyMath.GetConductorPitch();
+            float? floorSpeedAdd = (hitFloor ?? planet?.player?.currFloor?.prevfloor)?.speed;
+            double bpmTimesSpeed = scrConductor.instance.bpm * (floorSpeedAdd ?? 1.0);
+            double conductorPitch = scrConductor.instance.song.pitch;
 
             double pureBoundaryDeg = scrMisc.GetAdjustedAngleBoundaryInDeg(
                 HitMarginGeneral.Pure, bpmTimesSpeed, conductorPitch, marginScale);
@@ -157,8 +158,8 @@ namespace XPerfect
                     if (scrController.instance == null || scrConductor.instance == null)
                         return true;
 
-                    double bpmTimesSpeed = AccuracyMath.GetBpmTimesSpeed();
-                    double conductorPitch = AccuracyMath.GetConductorPitch();
+                    double bpmTimesSpeed = scrConductor.instance.bpm * ((hitFloor ?? scrController.instance.playerOne?.currFloor?.prevfloor)?.speed ?? 1.0);
+                    double conductorPitch = scrConductor.instance.song.pitch;
 
                     double xPerfectBoundary = AccuracyMath.GetMeterXPerfectBoundaryDeg(
                         bpmTimesSpeed,


### PR DESCRIPTION
## Bug Fixes

### 1. Judgment Consumption Race Condition
`MeterVisualPatch.AddHitPostfix` and `MistakesManagerAddHitPatch` both accessed `AccuracyState.LastJudge`. Depending on call order, either counting or tick compression would silently break.
- **Meter**: now independently determines XPerfect via `|normalizedAngle| ≤ xPerfectMeterBoundary`, no longer reads `LastJudge`
- **Tracker**: sole owner of `LastJudge` — reads, increments, consumes

### 2. Wrong BPM × Speed Calculation on Speed-Changing Levels
`AddHitPostfix` and `CalculateTickColor.Prefix` computed `bpmTimesSpeed` as `bpm × GCS.currentSpeedTrial × planetarySystem.speed`, ignoring per-floor speed multipliers.
- Changed to match the game's formula: `bpm × (hitFloor?.speed ?? planet?.player.currFloor.prevfloor?.speed ?? 1f)`
- Removed now-unused `GetBpmTimesSpeed()` / `GetConductorPitch()`

### 3. Auto-Play False Deaths at High BPM
`GetDetailedJudge` correctly returned XPerfect (via `RDC.auto` check), but `IsValidHitPatch` then rejected the hit because `margin ≠ Perfect`. At high BPM, floating-point precision causes auto-aim to produce `EarlyPerfect` instead of `Perfect`.
- Added `if (RDC.auto) return;` at the top of `IsValidHitPatch` — auto-play never blocks

### 4. Stale `ShouldFailPlayer` Flag
When XPerfectOnly was toggled off after a blocked hit, the flag was never cleared. Re-enabling it could cause an unjust death on the next `SwitchChosen`.
- `SwitchChosenFailPatch` now **clears the flag unconditionally first**, then checks conditions

### 5. Sprite Loading Doesn't Retry Individual Failures
`EnsureSpritesLoaded` used `||` to mark both sprites as loaded. If one file was missing/corrupt, it was never retried.
- Each sprite is now checked independently; a failed file is retried on the next `EnsureSpritesLoaded` call

### 6. Auto Tile & Auto-Play Text/Counting
- `HitMargin.Auto` could enter the `else` branch and read a stale `LastJudge`, causing false deaths
- Auto-play hits are now properly counted, displayed, and never blocked
- Removed redundant `else if (margin == HitMargin.Perfect)` guard

## Performance

| Change | Impact |
|---|---|
| `FieldInfo.GetValue()` → `FieldRef` delegates | Eliminates reflection + int boxing on hot path |
| Reuse `countedBoundaryDeg` across methods | Saves one `GetAdjustedAngleBoundaryInDeg` per hit |
| `StringBuilder` with manual digit writing | Hot path allocates only `sb.ToString()` (1 string vs. 5–8) |
| Compile-time color hex caching | 3× `ToHtmlStringRGB` eliminated per hit |
| Removed try-catch from 4 hot-path patches | Unblocks JIT inlining |
| Merged duplicate `AddHit` / `Start_Rewind` patches | 2 fewer Harmony delegate invocations per hit/level-start |
| `ApplySettings` dirty-checking | Skips transform/font writes when unchanged |

## Cleanup

- Removed dead fields: `LastJudgeConsumedByMeter`, `originalSpritesCaptured`, `loaded`
- Removed dead methods: `GetBpmTimesSpeed()`, `GetConductorPitch()`
- Replaced deprecated `FindObjectsOfType` with `FindObjectsByType`
