### PR TITLE
Co-op support, checkpoint revert, robustness fixes

### DIFF
--- a/AccuracySystem.cs
+++ b/AccuracySystem.cs
@@ -16,46 +16,165 @@ namespace XPerfect
 
     public static class AccuracyState
     {
-        public static int PlusPerfectCount { get; private set; }
-        public static int XPerfectCount { get; private set; }
-        public static int MinusPerfectCount { get; private set; }
+        private const int MaxPlayers = 4;
 
-        public static DetailedJudge LastJudge { get; private set; } = DetailedJudge.None;
-        public static DetailedJudge LastJudgeForText { get; private set; } = DetailedJudge.None;
+        private static int[] _plusCount = new int[MaxPlayers];
+        private static int[] _xCount = new int[MaxPlayers];
+        private static int[] _minusCount = new int[MaxPlayers];
+        private static List<DetailedJudge>[] _judgeHistory = new List<DetailedJudge>[MaxPlayers];
+        private static int[] _checkpointSize = new int[MaxPlayers];
+        private static DetailedJudge[] _lastJudge = new DetailedJudge[MaxPlayers];
+        private static DetailedJudge[] _lastJudgeForText = new DetailedJudge[MaxPlayers];
+        internal static int _currentPlayerId = 0;
 
-        public static void RecordJudge(DetailedJudge judge)
+        static AccuracyState()
         {
-            LastJudge = judge;
-            LastJudgeForText = judge;
+            for (int i = 0; i < MaxPlayers; i++)
+            {
+                _judgeHistory[i] = new List<DetailedJudge>();
+                _lastJudge[i] = DetailedJudge.None;
+                _lastJudgeForText[i] = DetailedJudge.None;
+            }
         }
 
-        public static void ConsumeJudge()
+        internal static int PlayerCount =>
+            Math.Min(scrMistakesManager.marginTrackers?.Length ?? 1, MaxPlayers);
+
+        public static int PlusPerfectCount
         {
-            LastJudge = DetailedJudge.None;
+            get { int p = 0; int n = PlayerCount; for (int i = 0; i < n; i++) p += _plusCount[i]; return p; }
         }
-        public static void ConsumeJudgeForText()
+        public static int XPerfectCount
         {
-            LastJudgeForText = DetailedJudge.None;
+            get { int x = 0; int n = PlayerCount; for (int i = 0; i < n; i++) x += _xCount[i]; return x; }
+        }
+        public static int MinusPerfectCount
+        {
+            get { int m = 0; int n = PlayerCount; for (int i = 0; i < n; i++) m += _minusCount[i]; return m; }
         }
 
-        public static void IncrementCount(DetailedJudge judge)
+
+        public static int GetCount(int player, DetailedJudge judge)
         {
+            if (player < 0 || player >= MaxPlayers) return 0;
             switch (judge)
             {
-                case DetailedJudge.PlusPerfect: PlusPerfectCount++; break;
-                case DetailedJudge.XPerfect: XPerfectCount++; break;
-                case DetailedJudge.MinusPerfect: MinusPerfectCount++; break;
+                case DetailedJudge.PlusPerfect: return _plusCount[player];
+                case DetailedJudge.XPerfect: return _xCount[player];
+                case DetailedJudge.MinusPerfect: return _minusCount[player];
+                default: return 0;
+            }
+        }
+
+        public static void GetCombinedCounts(out int plus, out int x, out int minus)
+        {
+            plus = 0; x = 0; minus = 0;
+            int n = PlayerCount;
+            for (int p = 0; p < n; p++)
+            {
+                plus += _plusCount[p];
+                x += _xCount[p];
+                minus += _minusCount[p];
+            }
+        }
+
+        public static int GetPlayerPlusPerfectCount(int player) => GetCount(player, DetailedJudge.PlusPerfect);
+        public static int GetPlayerXPerfectCount(int player) => GetCount(player, DetailedJudge.XPerfect);
+        public static int GetPlayerMinusPerfectCount(int player) => GetCount(player, DetailedJudge.MinusPerfect);
+
+        public static DetailedJudge LastJudge => _lastJudge[_currentPlayerId];
+        public static DetailedJudge LastJudgeForText => _lastJudgeForText[_currentPlayerId];
+
+        public static DetailedJudge GetPlayerLastJudge(int player)
+        {
+            return (player >= 0 && player < MaxPlayers) ? _lastJudge[player] : DetailedJudge.None;
+        }
+        public static DetailedJudge GetPlayerLastJudgeForText(int player)
+        {
+            return (player >= 0 && player < MaxPlayers) ? _lastJudgeForText[player] : DetailedJudge.None;
+        }
+
+        public static void RecordJudge(int player, DetailedJudge judge)
+        {
+            if (player < 0 || player >= MaxPlayers) return;
+            _lastJudge[player] = judge;
+            _lastJudgeForText[player] = judge;
+        }
+
+        public static void ConsumeJudge(int player)
+        {
+            if (player < 0 || player >= MaxPlayers) return;
+            _lastJudge[player] = DetailedJudge.None;
+        }
+        public static void ConsumeJudgeForText(int player)
+        {
+            if (player < 0 || player >= MaxPlayers) return;
+            _lastJudgeForText[player] = DetailedJudge.None;
+        }
+
+        public static void AddHit(int player, DetailedJudge judge)
+        {
+            if (player < 0 || player >= PlayerCount) return;
+            _judgeHistory[player].Add(judge);
+            switch (judge)
+            {
+                case DetailedJudge.PlusPerfect: _plusCount[player]++; break;
+                case DetailedJudge.XPerfect: _xCount[player]++; break;
+                case DetailedJudge.MinusPerfect: _minusCount[player]++; break;
             }
         }
 
         public static void Reset()
         {
-            PlusPerfectCount = 0;
-            XPerfectCount = 0;
-            MinusPerfectCount = 0;
-            LastJudge = DetailedJudge.None;
-            LastJudgeForText = DetailedJudge.None;
+            for (int p = 0; p < MaxPlayers; p++)
+            {
+                _plusCount[p] = 0;
+                _xCount[p] = 0;
+                _minusCount[p] = 0;
+                _judgeHistory[p].Clear();
+                _checkpointSize[p] = 0;
+                _lastJudge[p] = DetailedJudge.None;
+                _lastJudgeForText[p] = DetailedJudge.None;
+            }
         }
+
+        public static void MarkCheckpoint(int player = 0)
+        {
+            if (player < 0 || player >= PlayerCount) return;
+            _checkpointSize[player] = _judgeHistory[player].Count;
+        }
+
+        public static void MarkAllCheckpoints()
+        {
+            for (int p = 0; p < PlayerCount; p++)
+                _checkpointSize[p] = _judgeHistory[p].Count;
+        }
+
+        public static void RevertToCheckpoint(int player = 0)
+        {
+            if (player < 0 || player >= PlayerCount) return;
+            var history = _judgeHistory[player];
+            while (history.Count > _checkpointSize[player])
+            {
+                int last = history.Count - 1;
+                DetailedJudge judge = history[last];
+                history.RemoveAt(last);
+                switch (judge)
+                {
+                    case DetailedJudge.PlusPerfect: _plusCount[player]--; break;
+                    case DetailedJudge.XPerfect: _xCount[player]--; break;
+                    case DetailedJudge.MinusPerfect: _minusCount[player]--; break;
+                }
+            }
+        }
+
+        public static void RevertAllToCheckpoint()
+        {
+            for (int p = 0; p < PlayerCount; p++)
+                RevertToCheckpoint(p);
+        }
+
+
     }
 
     public static class AccuracyMath
@@ -161,7 +280,7 @@ namespace XPerfect
                 __result, hitangle, refangle, isCW, bpmTimesSpeed2, conductorPitch2);
 
             if (detailedJudge != DetailedJudge.None)
-                AccuracyState.RecordJudge(detailedJudge);
+                AccuracyState.RecordJudge(AccuracyState._currentPlayerId, detailedJudge);
         }
     }
 
@@ -169,7 +288,14 @@ namespace XPerfect
     [HarmonyPriority(Priority.Normal)]
     public static class IsValidHitPatch
     {
-        internal static bool ShouldFailPlayer = false;
+        internal static bool[] ShouldFailPlayer = new bool[0];
+
+        internal static void EnsureCapacity()
+        {
+            int count = AccuracyState.PlayerCount;
+            if (ShouldFailPlayer.Length < count)
+                System.Array.Resize(ref ShouldFailPlayer, count);
+        }
 
         static void Postfix(ref bool __result, HitMargin margin)
         {
@@ -177,6 +303,8 @@ namespace XPerfect
             if (scrController.instance == null || !scrController.instance.gameworld) return;
 
             if (RDC.auto) return;
+
+            EnsureCapacity();
 
             bool shouldBlock = false;
 
@@ -194,8 +322,20 @@ namespace XPerfect
             if (shouldBlock)
             {
                 __result = false;
-                ShouldFailPlayer = true;
+                int pid = AccuracyState._currentPlayerId;
+                if (pid >= 0 && pid < ShouldFailPlayer.Length)
+                    ShouldFailPlayer[pid] = true;
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(scrPlanet), "SwitchChosen")]
+    [HarmonyPriority(Priority.High)]
+    public static class PlanetSwitchPrefix
+    {
+        static void Prefix(scrPlanet __instance)
+        {
+            AccuracyState._currentPlayerId = (__instance.player != null) ? __instance.player.playerID : 0;
         }
     }
 
@@ -203,21 +343,23 @@ namespace XPerfect
     [HarmonyPriority(Priority.Normal)]
     public static class SwitchChosenFailPatch
     {
-        static void Postfix()
+        static void Postfix(scrPlanet __instance)
         {
             try
             {
-                if (!IsValidHitPatch.ShouldFailPlayer) return;
-                IsValidHitPatch.ShouldFailPlayer = false;
+                int pid = (__instance.player != null) ? __instance.player.playerID : 0;
+                if (pid < 0 || pid >= IsValidHitPatch.ShouldFailPlayer.Length) return;
+                if (!IsValidHitPatch.ShouldFailPlayer[pid]) return;
+                IsValidHitPatch.ShouldFailPlayer[pid] = false;
 
                 if (!Main.Enabled || !Main.Settings.XPerfectOnly) return;
 
-                var ctrl = scrController.instance;
-                if (ctrl == null) return;
+                var player = __instance.player;
+                if (player == null) return;
 
-                ctrl.playerOne.Die(false, false, "", true);
+                player.Die(false, false, "", true);
             }
-            catch (Exception ex)
+            catch (System.Exception ex)
             {
                 UnityModManager.Logger.Log($"[XPerfect] SwitchChosen error: {ex}");
             }
@@ -228,18 +370,21 @@ namespace XPerfect
     [HarmonyPriority(Priority.Normal)]
     public static class MistakesManagerAddHitPatch
     {
-        static void Postfix(HitMargin hit)
+        static void Postfix(scrMarginTracker __instance, HitMargin hit)
         {
             if (!Main.Enabled) return;
             if (hit != HitMargin.Perfect) return;
             if (scrController.instance == null || scrConductor.instance == null) return;
             if ((States)scrController.instance.stateMachine.GetState() != States.PlayerControl) return;
 
-            DetailedJudge detailedJudge = AccuracyState.LastJudge;
+            int playerId = System.Array.IndexOf(scrMistakesManager.marginTrackers, __instance);
+            if (playerId < 0) playerId = 0;
+
+            DetailedJudge detailedJudge = AccuracyState.GetPlayerLastJudge(playerId);
             if (detailedJudge == DetailedJudge.None) return;
 
-            AccuracyState.IncrementCount(detailedJudge);
-            AccuracyState.ConsumeJudge();
+            AccuracyState.AddHit(playerId, detailedJudge);
+            AccuracyState.ConsumeJudge(playerId);
 
             CounterDisplay.Refresh();
         }
@@ -363,7 +508,7 @@ namespace XPerfect
             {
                 if (__instance != null && __instance.hitMargin == HitMargin.Perfect)
                 {
-                    AccuracyState.ConsumeJudgeForText();
+                    AccuracyState.ConsumeJudgeForText(AccuracyState._currentPlayerId);
                 }
             }
         }
@@ -374,47 +519,101 @@ namespace XPerfect
     {
         static void Postfix()
         {
-            AccuracyState.Reset();
-            IsValidHitPatch.ShouldFailPlayer = false;
+            if (GCS.checkpointNum == 0)
+            {
+                AccuracyState.Reset();
+            }
+            IsValidHitPatch.EnsureCapacity();
+            for (int i = 0; i < IsValidHitPatch.ShouldFailPlayer.Length; i++)
+                IsValidHitPatch.ShouldFailPlayer[i] = false;
             CounterDisplay.Refresh();
         }
     }
 
-    [HarmonyPatch(typeof(scrController), "OnLandOnPortal")]
-    public static class ResultsTextPatch
+    [HarmonyPatch(typeof(scrMistakesManager), "MarkCheckpoint")]
+    public static class CheckpointMarkPatch
     {
-        static void Postfix(scrController __instance)
+        static void Postfix()
+        {
+            AccuracyState.MarkAllCheckpoints();
+        }
+    }
+
+    [HarmonyPatch(typeof(scrMistakesManager), "RevertToLastCheckpoint")]
+    public static class CheckpointRestorePatch
+    {
+        static void Postfix()
+        {
+            AccuracyState.RevertAllToCheckpoint();
+        }
+    }
+
+    [HarmonyPatch(typeof(DetailedResults), "Show")]
+    public static class DetailedResultsShowPatch
+    {
+        static void Prefix()
+        {
+            DetailedResultsXPerfectPatch.ResetCache();
+        }
+    }
+
+    [HarmonyPatch(typeof(DetailedResults), "ShowForPlayer")]
+    public static class DetailedResultsXPerfectPatch
+    {
+        private static string _baseCongratsText = null;
+        private static string _purePerfectText = null;
+
+        public static void ResetCache()
+        {
+            _baseCongratsText = null;
+            _purePerfectText = null;
+        }
+
+        static void Postfix(DetailedResults __instance, int playerIndex)
         {
             if (!Main.Enabled) return;
-            if (__instance == null) return;
+            if (__instance == null || __instance.textComponent == null) return;
 
-            bool isPureXPerfectRun =
-                !__instance.startedFromCheckpoint &&
-                AccuracyState.XPerfectCount > 0 &&
-                AccuracyState.PlusPerfectCount == 0 &&
-                AccuracyState.MinusPerfectCount == 0;
+            var ctrl = scrController.instance;
 
-            if (isPureXPerfectRun &&
-                string.IsNullOrEmpty(__instance.customTxtPurePerfect) &&
-                __instance.mistakesManager.IsAllPurePerfect() &&
-                __instance.txtCongrats != null)
+            // Cache texts on first call
+            if (_baseCongratsText == null && ctrl?.txtCongrats != null)
             {
-                string shown = __instance.txtCongrats.text;
-                if (!string.IsNullOrEmpty(shown) && !shown.StartsWith("X"))
-                    __instance.txtCongrats.text = "X" + shown;
+                _baseCongratsText = ctrl.txtCongrats.text;
+                _purePerfectText = string.IsNullOrEmpty(ctrl.customTxtPurePerfect)
+                    ? RDString.Get("status.allPurePerfect")
+                    : ctrl.customTxtPurePerfect;
             }
 
-            var detailedResults = __instance.detailedResults;
-            if (detailedResults == null) return;
-            string text = detailedResults.textComponent.text;
+            // Per-player congrats text
+            // When pure XPerfect: show "X" + pure perfect text (e.g. "XPerfect!")
+            // Otherwise: show standard congrats text
+            bool startedFromCheckpoint = ctrl != null && ctrl.startedFromCheckpoint;
+            bool playerPurePerfect = playerIndex >= 0 && playerIndex < scrMistakesManager.marginTrackers.Length
+                && scrMistakesManager.marginTrackers[playerIndex].IsAllPurePerfect();
+            bool playerXPerfect = AccuracyState.GetPlayerXPerfectCount(playerIndex) > 0
+                && AccuracyState.GetPlayerPlusPerfectCount(playerIndex) == 0
+                && AccuracyState.GetPlayerMinusPerfectCount(playerIndex) == 0;
+
+            if (ctrl?.txtCongrats != null)
+            {
+                if (!startedFromCheckpoint && playerPurePerfect && _purePerfectText != null)
+                    ctrl.txtCongrats.text = playerXPerfect ? "X" + _purePerfectText : _purePerfectText;
+                else if (_baseCongratsText != null)
+                    ctrl.txtCongrats.text = _baseCongratsText;
+            }
+
+            // Append XPerfect detail to results text
+            int plus = AccuracyState.GetPlayerPlusPerfectCount(playerIndex);
+            int x = AccuracyState.GetPlayerXPerfectCount(playerIndex);
+            int minus = AccuracyState.GetPlayerMinusPerfectCount(playerIndex);
+
+            if (plus == 0 && x == 0 && minus == 0) return;
+
+            string text = __instance.textComponent.text;
             if (string.IsNullOrEmpty(text)) return;
 
-            string detail =
-                $" <color=#60FF4E>[+{AccuracyState.PlusPerfectCount}/</color>" +
-                $"<color=#4DCCFF>{AccuracyState.XPerfectCount}</color>" +
-                $"<color=#60FF4E>/-{AccuracyState.MinusPerfectCount}]</color>";
-
-            if (text.Contains(detail)) return;
+            string detail = $" <color=#4DCCFF>[+{plus}/{x}/-{minus}]</color>";
 
             const string separator = "     ";
             int firstNewline = text.IndexOf('\n');
@@ -425,13 +624,12 @@ namespace XPerfect
             if (tokens.Length >= 2)
             {
                 tokens[1] = tokens[1] + detail;
-                detailedResults.textComponent.text = string.Join(separator, tokens) + rest;
+                __instance.textComponent.text = string.Join(separator, tokens) + rest;
             }
             else
             {
-                detailedResults.textComponent.text = text + detail;
+                __instance.textComponent.text = text + detail;
             }
         }
     }
-
 }

--- a/AccuracySystem.cs
+++ b/AccuracySystem.cs
@@ -613,7 +613,7 @@ namespace XPerfect
             string text = __instance.textComponent.text;
             if (string.IsNullOrEmpty(text)) return;
 
-            string detail = $" <color=#4DCCFF>[+{plus}/{x}/-{minus}]</color>";
+            string detail = $" <color=#60FF4E>[+{plus}/</color><color=#4DCCFF>{x}</color><color=#60FF4E>/-{minus}]</color>";
 
             const string separator = "     ";
             int firstNewline = text.IndexOf('\n');

--- a/AccuracySystem.cs
+++ b/AccuracySystem.cs
@@ -188,12 +188,12 @@ namespace XPerfect
             return isCW ? delta : -delta;
         }
 
-        public static double GetActualXPerfectBoundaryDeg(double bpmTimesSpeed, double conductorPitch)
+        public static double GetActualXPerfectBoundaryDeg(double bpmTimesSpeed, double conductorPitch, float marginScale = 1f)
         {
             double xPerfectMinTimeDeg =
                 scrMisc.TimeToAngleInRad(XPerfectMinTimeSec, bpmTimesSpeed, conductorPitch, false) * Mathf.Rad2Deg;
 
-            return Math.Max(XPerfectBaseDeg, xPerfectMinTimeDeg);
+            return Math.Max(XPerfectBaseDeg * marginScale, xPerfectMinTimeDeg);
         }
 
         public static double GetMeterScale(double countedBoundaryDeg)
@@ -216,15 +216,16 @@ namespace XPerfect
                 marginScale
             );
 
-            return GetMeterXPerfectBoundaryDeg(bpmTimesSpeed, conductorPitch, countedBoundaryDeg);
+            return GetMeterXPerfectBoundaryDeg(bpmTimesSpeed, conductorPitch, countedBoundaryDeg, marginScale);
         }
 
         public static double GetMeterXPerfectBoundaryDeg(
             double bpmTimesSpeed,
             double conductorPitch,
-            double countedBoundaryDeg)
+            double countedBoundaryDeg,
+            float marginScale = 1f)
         {
-            double actualXPerfectBoundaryDeg = GetActualXPerfectBoundaryDeg(bpmTimesSpeed, conductorPitch);
+            double actualXPerfectBoundaryDeg = GetActualXPerfectBoundaryDeg(bpmTimesSpeed, conductorPitch, marginScale);
             double meterScale = GetMeterScale(countedBoundaryDeg);
 
             return actualXPerfectBoundaryDeg * meterScale;
@@ -239,7 +240,8 @@ namespace XPerfect
             float refAngle,
             bool isCW,
             double bpmTimesSpeed,
-            double conductorPitch)
+            double conductorPitch,
+            float marginScale = 1f)
         {
             if (RDC.auto)
                 return DetailedJudge.XPerfect;
@@ -251,7 +253,7 @@ namespace XPerfect
             float absDeltaDeg = Mathf.Abs(signedDeltaDeg);
 
             double xPerfectBoundaryDeg =
-                AccuracyMath.GetActualXPerfectBoundaryDeg(bpmTimesSpeed, conductorPitch);
+                AccuracyMath.GetActualXPerfectBoundaryDeg(bpmTimesSpeed, conductorPitch, marginScale);
 
             if (absDeltaDeg <= xPerfectBoundaryDeg)
                 return DetailedJudge.XPerfect;
@@ -277,7 +279,7 @@ namespace XPerfect
             double conductorPitch2 = (double)conductorPitch;
 
             DetailedJudge detailedJudge = JudgeCalculator.GetDetailedJudge(
-                __result, hitangle, refangle, isCW, bpmTimesSpeed2, conductorPitch2);
+                __result, hitangle, refangle, isCW, bpmTimesSpeed2, conductorPitch2, (float)marginScale);
 
             if (detailedJudge != DetailedJudge.None)
                 AccuracyState.RecordJudge(AccuracyState._currentPlayerId, detailedJudge);

--- a/Counterdisplay.cs
+++ b/Counterdisplay.cs
@@ -168,23 +168,42 @@ namespace XPerfect
             var sb = _counterBuilder;
             sb.Length = 0;
 
-            sb.Append("<color=#");
-            sb.Append(PlusMinusHex);
-            sb.Append(">+");
-            AppendInt(sb, AccuracyState.PlusPerfectCount);
-            sb.Append("</color>");
-            sb.Append(space);
-            sb.Append("<color=#");
-            sb.Append(XColorHex);
-            sb.Append(">");
-            AppendInt(sb, AccuracyState.XPerfectCount);
-            sb.Append("</color>");
-            sb.Append(space);
-            sb.Append("<color=#");
-            sb.Append(PlusMinusHex);
-            sb.Append(">-");
-            AppendInt(sb, AccuracyState.MinusPerfectCount);
-            sb.Append("</color>");
+            bool coop = scrController.coopMode;
+            int count = coop ? AccuracyState.PlayerCount : 1;
+
+            for (int p = 0; p < count; p++)
+            {
+                if (p > 0) sb.Append('\n');
+
+                if (coop)
+                {
+                    string col = GetPlayerColor(p);
+
+                    sb.Append("<color=#");
+                    sb.Append(col);
+                    sb.Append(">P");
+                    AppendInt(sb, p + 1);
+                    sb.Append("</color> ");
+                }
+
+                sb.Append("<color=#");
+                sb.Append(PlusMinusHex);
+                sb.Append(">+");
+                AppendInt(sb, coop ? AccuracyState.GetPlayerPlusPerfectCount(p) : AccuracyState.PlusPerfectCount);
+                sb.Append("</color>");
+                sb.Append(space);
+                sb.Append("<color=#");
+                sb.Append(XColorHex);
+                sb.Append(">");
+                AppendInt(sb, coop ? AccuracyState.GetPlayerXPerfectCount(p) : AccuracyState.XPerfectCount);
+                sb.Append("</color>");
+                sb.Append(space);
+                sb.Append("<color=#");
+                sb.Append(PlusMinusHex);
+                sb.Append(">-");
+                AppendInt(sb, coop ? AccuracyState.GetPlayerMinusPerfectCount(p) : AccuracyState.MinusPerfectCount);
+                sb.Append("</color>");
+            }
 
             _text.text = sb.ToString();
 
@@ -193,7 +212,15 @@ namespace XPerfect
 
         private static void AppendInt(StringBuilder sb, int value)
         {
-            if (value >= 1000)
+            if (value >= 10000)
+            {
+                sb.Append((char)('0' + (value / 10000) % 10));
+                sb.Append((char)('0' + (value / 1000) % 10));
+                sb.Append((char)('0' + (value / 100) % 10));
+                sb.Append((char)('0' + (value / 10) % 10));
+                sb.Append((char)('0' + value % 10));
+            }
+            else if (value >= 1000)
             {
                 sb.Append((char)('0' + (value / 1000) % 10));
                 sb.Append((char)('0' + (value / 100) % 10));
@@ -214,6 +241,28 @@ namespace XPerfect
             else
             {
                 sb.Append((char)('0' + value));
+            }
+        }
+
+        private static string GetPlayerColor(int player)
+        {
+            try
+            {
+                if (scrPlayerManager.playerColors != null && player < scrPlayerManager.playerColors.Length)
+                {
+                    var c = scrPlayerManager.playerColors[player].ToRealColor();
+                    return ColorUtility.ToHtmlStringRGB(c);
+                }
+            }
+            catch { }
+            // Fallback: game defaults (P1=CoopRed, P2=CoopBlue, P3=CoopYellow, P4=CoopGreen)
+            switch (player)
+            {
+                case 0: return "FF4444";
+                case 1: return "4488FF";
+                case 2: return "FFD700";
+                case 3: return "44DD44";
+                default: return "FFFFFF";
             }
         }
 

--- a/MeterVisualPatch.cs
+++ b/MeterVisualPatch.cs
@@ -146,7 +146,7 @@ namespace XPerfect
             const float xCompress = 0.75f;
 
             double xPerfectMeterBoundary = AccuracyMath.GetMeterXPerfectBoundaryDeg(
-                bpmTimesSpeed, conductorPitch, countedBoundaryDeg);
+                bpmTimesSpeed, conductorPitch, countedBoundaryDeg, marginScale);
 
             if (Math.Abs(normalizedAngle) <= xPerfectMeterBoundary)
             {

--- a/MeterVisualPatch.cs
+++ b/MeterVisualPatch.cs
@@ -26,8 +26,19 @@ namespace XPerfect
         private static Sprite straightSprite;
         private static Sprite curvedSprite;
 
-        private static Sprite originalStraightSprite;
-        private static Sprite originalCurvedSprite;
+        private static readonly System.Collections.Generic.Dictionary<int, (Sprite straight, Sprite curved)> _originalSprites =
+            new System.Collections.Generic.Dictionary<int, (Sprite straight, Sprite curved)>();
+
+        private static (Sprite straight, Sprite curved) GetOrCreateOriginalEntry(scrHitErrorMeter meter)
+        {
+            int key = meter.GetInstanceID();
+            if (!_originalSprites.TryGetValue(key, out var entry))
+            {
+                entry = (null, null);
+                _originalSprites[key] = entry;
+            }
+            return entry;
+        }
 
         [HarmonyPatch(typeof(scrHitErrorMeter), "UpdateLayout")]
         [HarmonyPostfix]
@@ -179,31 +190,38 @@ namespace XPerfect
         {
             if (meter == null) return;
 
+            var entry = GetOrCreateOriginalEntry(meter);
+
             if (meter.straightMeter != null)
             {
                 Image image = meter.straightMeter.GetComponent<Image>();
                 if (image != null && image.sprite != straightSprite)
-                    originalStraightSprite = image.sprite;
+                    _originalSprites[meter.GetInstanceID()] = (straight: image.sprite, curved: entry.curved);
             }
 
             if (meter.curvedMeter != null)
             {
                 Image image = meter.curvedMeter.GetComponent<Image>();
                 if (image != null && image.sprite != curvedSprite)
-                    originalCurvedSprite = image.sprite;
+                {
+                    var current = _originalSprites[meter.GetInstanceID()];
+                    _originalSprites[meter.GetInstanceID()] = (straight: current.straight, curved: image.sprite);
+                }
             }
         }
 
         private static void RestoreOriginalSprites(scrHitErrorMeter meter)
         {
-            if (meter == null)
-                return;
+            if (meter == null) return;
 
-            if (meter.straightMeter != null && originalStraightSprite != null)
-                ReplaceRootImageOnly(meter.straightMeter, originalStraightSprite);
+            if (_originalSprites.TryGetValue(meter.GetInstanceID(), out var entry))
+            {
+                if (meter.straightMeter != null && entry.straight != null)
+                    ReplaceRootImageOnly(meter.straightMeter, entry.straight);
 
-            if (meter.curvedMeter != null && originalCurvedSprite != null)
-                ReplaceRootImageOnly(meter.curvedMeter, originalCurvedSprite);
+                if (meter.curvedMeter != null && entry.curved != null)
+                    ReplaceRootImageOnly(meter.curvedMeter, entry.curved);
+            }
         }
 
         private static float GetMeterAngleFromTick(Image tickImage, ErrorMeterShape meterShape)
@@ -275,36 +293,43 @@ namespace XPerfect
         {
             byte[] bytes = File.ReadAllBytes(filePath);
             Texture2D texture = new Texture2D(2, 2, TextureFormat.ARGB32, false);
-
-            var imageConversionType = Type.GetType("UnityEngine.ImageConversion, UnityEngine.ImageConversionModule");
-            if (imageConversionType == null)
+            try
             {
-                UnityModManager.Logger.Log("[MeterVisualPatch] ImageConversion type not found");
-                return null;
+                var imageConversionType = Type.GetType("UnityEngine.ImageConversion, UnityEngine.ImageConversionModule");
+                if (imageConversionType == null)
+                {
+                    UnityModManager.Logger.Log("[MeterVisualPatch] ImageConversion type not found");
+                    return null;
+                }
+                var loadImage = imageConversionType.GetMethod(
+                    "LoadImage",
+                    System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public,
+                    null,
+                    new System.Type[] { typeof(Texture2D), typeof(byte[]) },
+                    null
+                );
+                if (loadImage == null)
+                {
+                    UnityModManager.Logger.Log("[MeterVisualPatch] LoadImage method not found");
+                    return null;
+                }
+                bool success = (bool)loadImage.Invoke(null, new object[] { texture, bytes });
+                if (!success)
+                    return null;
+
+                texture.wrapMode = TextureWrapMode.Clamp;
+                texture.filterMode = FilterMode.Bilinear;
+
+                Rect rect = new Rect(0f, 0f, texture.width, texture.height);
+                Vector2 pivot = new Vector2(0.5f, 0.5f);
+
+                return Sprite.Create(texture, rect, pivot, 100f);
             }
-            var loadImage = imageConversionType.GetMethod(
-                "LoadImage",
-                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public,
-                null,
-                new System.Type[] { typeof(Texture2D), typeof(byte[]) },
-                null
-            );
-            if (loadImage == null)
+            catch
             {
-                UnityModManager.Logger.Log("[MeterVisualPatch] LoadImage method not found");
-                return null;
+                if (texture != null) UnityEngine.Object.Destroy(texture);
+                throw;
             }
-            bool success = (bool)loadImage.Invoke(null, new object[] { texture, bytes });
-            if (!success)
-                return null;
-
-            texture.wrapMode = TextureWrapMode.Clamp;
-            texture.filterMode = FilterMode.Bilinear;
-
-            Rect rect = new Rect(0f, 0f, texture.width, texture.height);
-            Vector2 pivot = new Vector2(0.5f, 0.5f);
-
-            return Sprite.Create(texture, rect, pivot, 100f);
         }
         public static void RefreshAllMeters()
         {

--- a/MeterVisualPatch.cs
+++ b/MeterVisualPatch.cs
@@ -293,6 +293,7 @@ namespace XPerfect
         {
             byte[] bytes = File.ReadAllBytes(filePath);
             Texture2D texture = new Texture2D(2, 2, TextureFormat.ARGB32, false);
+            bool adopted = false;
             try
             {
                 var imageConversionType = Type.GetType("UnityEngine.ImageConversion, UnityEngine.ImageConversionModule");
@@ -323,12 +324,13 @@ namespace XPerfect
                 Rect rect = new Rect(0f, 0f, texture.width, texture.height);
                 Vector2 pivot = new Vector2(0.5f, 0.5f);
 
+                adopted = true;
                 return Sprite.Create(texture, rect, pivot, 100f);
             }
-            catch
+            finally
             {
-                if (texture != null) UnityEngine.Object.Destroy(texture);
-                throw;
+                if (texture != null && !adopted)
+                    UnityEngine.Object.Destroy(texture);
             }
         }
         public static void RefreshAllMeters()


### PR DESCRIPTION
## Summary

This PR adds full co-op (multiplayer) support, a checkpoint revert system that mirrors the game's own margin tracking, and fixes several robustness issues including race conditions, resource leaks, and bounds violations.

## Co-op / Multi-player

- **AccuracyState**: All state is now per-player (`_plusCount[]`, `_xCount[]`, `_minusCount[]`, `_judgeHistory[]`, `_lastJudge[]`, `_lastJudgeForText[]`). Supports up to `MaxPlayers = 4`.
- **`PlanetSwitchPrefix`**: A new Prefix hook on `scrPlanet.SwitchChosen` sets `_currentPlayerId` so downstream patches know which player is active.
- **`HitMarginPatch`**: `RecordJudge` now stores the judge per-player via `_currentPlayerId`.
- **`IsValidHitPatch`**: `ShouldFailPlayer` is now `bool[]` indexed by player ID, preventing cross-player kills.
- **`SwitchChosenFailPatch`**: Kills `__instance.player` (the correct player) instead of `ctrl.playerOne`.
- **`MistakesManagerAddHitPatch`**: Determines player ID from `scrMistakesManager.marginTrackers` index.
- **`CounterDisplay`**: Shows per-player counts on separate lines in co-op mode. Player colors read from `scrPlayerManager.playerColors` (the game's own color table).
- **`DetailedResultsXPerfectPatch`**: New Postfix on `DetailedResults.ShowForPlayer` — appends per-player XPerfect stats and updates the congrats title per player on cycle (co-op).

## Checkpoint revert

- **`_judgeHistory`**: Stores a `List<DetailedJudge>` per player, mirroring `scrMarginTracker.hitMargins`.
- **`_checkpointSize`**: Saved at `MarkCheckpoint` time, matching the game's `lastHitMarginsSize`.
- **`RevertToCheckpoint` / `RevertAllToCheckpoint`**: Pops judgments and decrements counts, identical in logic to `scrMarginTracker.RevertToLastCheckpoint`.
- **`MarkAllCheckpoints`**: Saves checkpoint state for all active players.

## Bug fixes

| Issue | Fix |
|---|---|
| Multiple `scrHitErrorMeter` instances overwriting original sprites | Static fields → `Dictionary<int, (straight, curved)>` keyed by instance ID |
| `Texture2D` leak in `LoadSprite` on failure paths | `adopted` flag + `finally` destroys unadopted textures on any exit |
| `AppendInt` could not display counts ≥ 10000 | Added 5-digit branch |
| `PlayerCount` returned 0 for empty `marginTrackers` array | `Math.Min(?.Length ?? 1, MaxPlayers)` |
| `GetCount` could index out of bounds | Added `player < 0 \|\| player >= MaxPlayers` guard |
| `RevertToCheckpoint` could read past array | Uses `MaxPlayers`-capped `PlayerCount` |
| [#2]XPerfect boundary ignored `marginScale` — zone didn't scale with custom hit window | `XPerfectBaseDeg * marginScale` in `GetActualXPerfectBoundaryDeg`, propagated through all call sites |

## Performance

- Removed `try-catch` from 4 hot-path patches (Harmony catches Prefix exceptions, Postfix only runs after original method).
- `FieldInfo.GetValue` → `AccessTools.FieldRef` delegates in `MeterVisualPatch`.
- Reused `countedBoundaryDeg` across boundary calculations.
- `StringBuilder` with manual digit-writing in counter display.
- Color hex caching (`ColorUtility.ToHtmlStringRGB` called once at init, not per-hit).

## Breaking changes

- `AccuracyState.PlusPerfectCount` / `XPerfectCount` / `MinusPerfectCount` now return combined counts across all active players (backward-compatible for single-player, extended for co-op).
- `GetPlayerPlusPerfectCount(player)`, `GetPlayerXPerfectCount(player)`, `GetPlayerMinusPerfectCount(player)` added for per-player access.
- `GetBpmTimesSpeed()` / `GetConductorPitch()` removed (callers now compute floor-speed-aware BPM inline).


<img width="372" height="280" alt="image" src="https://github.com/user-attachments/assets/26d8c06b-97eb-4ea7-9474-04b65c76e6cc" />

<img width="1920" height="1080" alt="QQ_1783362963091" src="https://github.com/user-attachments/assets/248ccec1-dfb5-4aaf-b58a-f0e3f60f8c03" />
<img width="1920" height="1080" alt="QQ_1783362966334" src="https://github.com/user-attachments/assets/f2484a56-4d4c-47f9-8983-819700fc942d" />