### PR TITLE
fix(meter): remove pitch tick compression to reflect true hit error

### DIFF
--- a/MeterVisualPatch.cs
+++ b/MeterVisualPatch.cs
@@ -136,15 +136,12 @@ namespace XPerfect
                 if (normalizedAngle < -normalizedPureBoundary || normalizedAngle > normalizedPureBoundary)
                     return;
 
-                const float xCompress = 0.75f;
-
                 double xPerfectMeterBoundary = AccuracyMath.GetMeterXPerfectBoundaryDeg(
                     bpmTimesSpeed, conductorPitch, countedBoundaryDeg, marginScale);
 
                 if (Math.Abs(normalizedAngle) <= xPerfectMeterBoundary)
                 {
-                    float finalAngle = normalizedAngle * xCompress;
-                    ApplyTickAngle(tickImage, meterShape, finalAngle);
+                    ApplyTickAngle(tickImage, meterShape, normalizedAngle);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Problem

Previously, the mod applied a `0.75f` coordinate compression factor (`xCompress`) to ticks falling within the XPerfect range in `MeterVisualPatch.cs`. This caused:

1. **Inaccurate visual positioning** — tick positions were artificially squeezed toward the center by 25%, failing to accurately reflect the player's actual deviation from the true hit timing.

2. **Overcrowded display** — ticks in the center area became too densely stacked, negatively impacting visual clarity.

## Changes

* Removed the `* 0.75f` coordinate scaling logic applied to `normalizedAngle` in the `AddHitPostfix` method within `MeterVisualPatch.cs`.

---

**Before**
<img width="627" height="240" alt="nofix" src="https://github.com/user-attachments/assets/66a0bfb2-5311-476a-8689-8b9aabf627d8" />
**After**
<img width="624" height="211" alt="2026-08-22 12-11-50_remuxed 00_02_10_05 Still001" src="https://github.com/user-attachments/assets/f06adf88-47e4-4437-b0e3-e857c6c6d8e9" />
